### PR TITLE
fix(ci): build publish job from source instead of cross-job artifact

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -125,13 +125,6 @@ jobs:
 
           echo "✅ Build validation passed"
 
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: staking-list-build
-          path: build/
-          retention-days: 7
-
   version-bump:
     name: 📝 Version Bump
     runs-on: ubuntu-latest
@@ -226,16 +219,10 @@ jobs:
           npm install -g npm@latest
           npm --version
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: staking-list-build
-          path: build/
-
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Rebuild (ensure consistency)
+      - name: Build from tagged source
         run: npm run build
 
       - name: Pre-publish verification


### PR DESCRIPTION
## What

The publish job restored a `build/` artifact produced by the test job, then ran `npm run build`, which clears `build/` and regenerates it from source. The restored artifact was never used — it only added a point of failure.

## Change

- Build from the checked-out source in the publish job.
- Remove the now-unused artifact upload in the test job.
- Rename the build step to reflect that it is the build, not a rebuild over a restored artifact.

Net effect: the test job validates, the publish job builds and publishes from source. No cross-job artifact to fail on.