### PR TITLE
fix(ci): harden sync/publish workflows and fix prerelease version parse

### DIFF
--- a/.github/workflows/auto-sync-syrups.yaml
+++ b/.github/workflows/auto-sync-syrups.yaml
@@ -73,14 +73,12 @@ jobs:
           CLIENT_NETWORKS: ${{ github.event.client_payload.networks }}
           INPUT_NETWORKS: ${{ inputs.networks }}
         run: |
-          # Get networks from dispatch payload or workflow input
           if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
             NETWORKS="$CLIENT_NETWORKS"
           else
             NETWORKS="$INPUT_NETWORKS"
           fi
           
-          # Default to base if empty
           if [ -z "$NETWORKS" ]; then
             NETWORKS="base"
           fi
@@ -95,8 +93,7 @@ jobs:
         run: |
           NETWORKS="$STEP_NETWORKS"
           SYNCED=""
-          
-          # Process each network
+
           for network in $(echo "$NETWORKS" | tr ',' ' '); do
             INPUT_FILE="syrup-staking-contract/deployments/syrup-${network}.json"
             

--- a/.github/workflows/auto-sync-syrups.yaml
+++ b/.github/workflows/auto-sync-syrups.yaml
@@ -44,12 +44,12 @@ jobs:
           repositories: syrup-staking-contract
 
       - name: Checkout this repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Checkout syrup-staking-contract
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: QuickSwap/syrup-staking-contract
           token: ${{ steps.app-token.outputs.token }}
@@ -59,7 +59,7 @@ jobs:
             deployments
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/auto-sync-syrups.yaml
+++ b/.github/workflows/auto-sync-syrups.yaml
@@ -69,12 +69,15 @@ jobs:
 
       - name: Determine networks to sync
         id: networks
+        env:
+          CLIENT_NETWORKS: ${{ github.event.client_payload.networks }}
+          INPUT_NETWORKS: ${{ inputs.networks }}
         run: |
           # Get networks from dispatch payload or workflow input
           if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
-            NETWORKS="${{ github.event.client_payload.networks }}"
+            NETWORKS="$CLIENT_NETWORKS"
           else
-            NETWORKS="${{ inputs.networks }}"
+            NETWORKS="$INPUT_NETWORKS"
           fi
           
           # Default to base if empty
@@ -87,8 +90,10 @@ jobs:
 
       - name: Sync syrup data
         id: sync
+        env:
+          STEP_NETWORKS: ${{ steps.networks.outputs.networks }}
         run: |
-          NETWORKS="${{ steps.networks.outputs.networks }}"
+          NETWORKS="$STEP_NETWORKS"
           SYNCED=""
           
           # Process each network
@@ -141,7 +146,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.git_status.outputs.has_diff == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: sync syrup pools from deployment"
@@ -177,14 +182,16 @@ jobs:
             syrups
 
       - name: Summary
+        env:
+          SYNCED_NETWORKS: ${{ steps.sync.outputs.synced_networks }}
         run: |
           echo "## 🔄 Sync Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           if [ "${{ steps.git_status.outputs.has_diff }}" == "true" ]; then
             echo "✅ **PR Created:** A pull request has been created with the synced data." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Networks synced:** ${{ steps.sync.outputs.synced_networks }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Networks synced:** $SYNCED_NETWORKS" >> $GITHUB_STEP_SUMMARY
           else
             echo "ℹ️ **No changes:** The staking data is already up to date." >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,9 +28,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write
-  id-token: write
-  pull-requests: read
+  contents: read
 
 jobs:
   security-audit:
@@ -132,6 +130,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && !inputs.dry_run
     timeout-minutes: 5
 
+    permissions:
+      contents: write
+
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
 
@@ -178,6 +179,10 @@ jobs:
         (github.event_name == 'workflow_dispatch' && !inputs.dry_run && needs.version-bump.result == 'success')
       )
     timeout-minutes: 10
+
+    permissions:
+      contents: write
+      id-token: write
 
     environment:
       name: npm-production
@@ -266,7 +271,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,12 +38,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js 20 LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js 20 LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -138,13 +138,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 
@@ -190,7 +190,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -214,7 +214,7 @@ jobs:
           fi
 
       - name: Setup Node.js with NPM registry
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24" # Node 24 required for OIDC publishing (npm/cli#8730)
           registry-url: "https://registry.npmjs.org/"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,10 +6,10 @@ jobs:
     name: Unit Tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js 20 LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 node_modules
 build/
+syrup-staking-contract/

--- a/src/build.js
+++ b/src/build.js
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 /**
  * Build all staking lists.
- * 
+ *
  * Reads unified data files from src/data/<type>.json (keyed by chainId)
  * and outputs unified build files to build/<type>.json
- * 
+ *
  * Data file format (input and output):
  *   {
- *     "137": { "name": "...", "active": [...], "closed": [...] },
- *     "8453": { "name": "...", "active": [...], "closed": [...] }
+ *     "137": [ ...items... ],
+ *     "8453": [ ...items... ]
  *   }
- * 
+ *
  * Output files:
  *   build/syrups.json
  *   build/lpfarms.json
@@ -25,10 +25,8 @@ const { buildList } = require('./lib/buildList');
 const DATA_DIR = path.join(__dirname, 'data');
 const BUILD_DIR = path.join(__dirname, '..', 'build');
 
-// Ensure build directory exists
 fs.mkdirSync(BUILD_DIR, { recursive: true });
 
-// Type display names
 const TYPE_NAMES = {
   syrups: 'Syrups',
   lpfarms: 'LP Farms',
@@ -36,14 +34,13 @@ const TYPE_NAMES = {
 };
 
 const { version } = require('../package.json');
-const parsedVersion = version.split('.');
+const parsedVersion = version.split('-')[0].split('.');
 
 let totalFiles = 0;
 
 for (const stakeType of STAKE_TYPES) {
   const inputFile = path.join(DATA_DIR, `${stakeType}.json`);
 
-  // Skip if file doesn't exist
   if (!fs.existsSync(inputFile)) {
     console.log(`⏭️  Skipping ${stakeType}: no data file`);
     continue;
@@ -52,7 +49,6 @@ for (const stakeType of STAKE_TYPES) {
   const dataByChain = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
   const typeName = TYPE_NAMES[stakeType] || stakeType;
 
-  // Build output object with all chains
   const output = {
     name: `Quickswap ${typeName}`,
     timestamp: new Date().toISOString(),
@@ -67,7 +63,6 @@ for (const stakeType of STAKE_TYPES) {
   let totalActive = 0;
   let totalClosed = 0;
 
-  // Process each chain
   for (const [chainKey, chainConfig] of Object.entries(CHAINS)) {
     const chainIdStr = String(chainConfig.chainId);
     const chainItems = dataByChain[chainIdStr] || [];

--- a/src/lib/buildList.js
+++ b/src/lib/buildList.js
@@ -24,9 +24,6 @@ function buildList({ name, chainId, logoURI, items }) {
   const closed = [];
 
   for (const item of items) {
-    // Classify by `ending` timestamp
-    // If no `ending` or `ending` is in the future → active
-    // If `ending` is in the past → closed
     const ending = item.ending;
     const isEnded = typeof ending === 'number' && ending < nowSeconds;
 

--- a/src/lib/buildList.js
+++ b/src/lib/buildList.js
@@ -17,7 +17,7 @@ const { version } = require('../../package.json');
  * @returns {Object} Formatted list with active/closed arrays
  */
 function buildList({ name, chainId, logoURI, items }) {
-  const parsed = version.split('.');
+  const parsed = version.split('-')[0].split('.');
   const nowSeconds = Math.floor(Date.now() / 1000);
 
   const active = [];

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,21 +1,21 @@
 #!/usr/bin/env node
 /**
  * Sync staking data from external deployment files.
- * 
+ *
  * Usage:
  *   node src/sync.js --in <path> --chain <chain> --type <type>
- * 
+ *
  * Examples:
  *   node src/sync.js --in ../syrup-staking-contract/deployments/syrup-base.json --chain base --type syrups
  *   node src/sync.js --in ./polygon-farms.json --chain polygon --type lpfarms
- * 
+ *
  * Input file format (from deployment repos):
  *   {
  *     "name": "...",
  *     "active": [ { ... } ],
  *     "closed": [ { ... } ]
  *   }
- * 
+ *
  * Data is stored in unified files keyed by chainId:
  *   {
  *     "137": [...polygon items...],
@@ -78,7 +78,6 @@ function main() {
   const type = args.type;
   const merge = args.merge !== 'false'; // Default: true
 
-  // Validate arguments
   if (!inputPath || !chain || !type) {
     console.error('❌ Missing required arguments\n');
     printUsage();
@@ -100,7 +99,6 @@ function main() {
   const chainConfig = CHAINS[chain];
   const chainIdStr = String(chainConfig.chainId);
 
-  // Read input file
   const absoluteInput = path.resolve(inputPath);
   if (!fs.existsSync(absoluteInput)) {
     console.error(`❌ Input file not found: ${absoluteInput}`);
@@ -109,19 +107,16 @@ function main() {
 
   const inputData = JSON.parse(fs.readFileSync(absoluteInput, 'utf8'));
 
-  // Extract items from input (support both formats)
+  // Accept either a bare array or an { active, closed } object
   let newItems = [];
   if (Array.isArray(inputData)) {
-    // Direct array format
     newItems = inputData;
   } else {
-    // Object with active/closed arrays
     const active = Array.isArray(inputData.active) ? inputData.active : [];
     const closed = Array.isArray(inputData.closed) ? inputData.closed : [];
     newItems = [...active, ...closed];
   }
 
-  // Validate items
   for (const [idx, item] of newItems.entries()) {
     if (!item || typeof item !== 'object') {
       console.error(`❌ Item ${idx} is not an object`);
@@ -133,35 +128,28 @@ function main() {
     }
   }
 
-  // Output file (unified data file)
   const outputPath = path.join(__dirname, 'data', `${type}.json`);
 
-  // Create data directory if it doesn't exist
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
-  // Load existing data or create empty object
   let dataByChain = {};
   if (fs.existsSync(outputPath)) {
     dataByChain = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
   }
 
-  // Get existing items for this chain
   const existingItems = dataByChain[chainIdStr] || [];
 
-  // Merge or replace
   let finalItems = [];
   if (merge && existingItems.length > 0) {
-    // Create map of existing items by stakingRewardAddress
     const existingMap = new Map();
     for (const item of existingItems) {
       const key = normalizeAddress(item.stakingRewardAddress);
       existingMap.set(key, item);
     }
 
-    // Add/update with new items
     for (const item of newItems) {
       const key = normalizeAddress(item.stakingRewardAddress);
-      existingMap.set(key, item); // Overwrites if exists
+      existingMap.set(key, item); // Overwrites existing entry with same address
     }
 
     finalItems = Array.from(existingMap.values());
@@ -171,10 +159,8 @@ function main() {
     console.log(`📦 Replacing ${chain} with ${newItems.length} items`);
   }
 
-  // Sort and update data
   dataByChain[chainIdStr] = stableSort(finalItems);
 
-  // Write back
   fs.writeFileSync(outputPath, JSON.stringify(dataByChain, null, 2) + '\n', 'utf8');
 
   console.log(`✅ Wrote ${finalItems.length} items for ${chainConfig.name} → ${outputPath}`);


### PR DESCRIPTION
## Summary

Best-practice hardening pass on the CI/publish pipeline, plus a runtime bump. Applies changes reviewed but not part of the original #16 merge.

- **auto-sync-syrups.yaml**: route workflow inputs and step outputs through `env:` for safe handling; pin `peter-evans/create-pull-request` to a commit SHA.
- **publish.yaml**: scope job permissions to least privilege — top-level `contents: read`, `contents: write` only on version-bump, `id-token: write` only on the publish job. Pin `softprops/action-gh-release` to a commit SHA. OIDC Trusted Publisher + `--provenance` unchanged.
- **build.js / buildList.js**: normalize version parsing so a prerelease bump produces valid numeric fields.
- Remove the stray `syrup-staking-contract` submodule reference; ignore the CI checkout path so it is not re-committed.
- Bump `actions/checkout` and `actions/setup-node` to v5 (Node 24 runtime; clears deprecation warnings).
- Tidy redundant comments; correct the `build.js` data-format docblock.

## Testing

- `npm test` -> 36 passing
- All three workflow YAML files validate